### PR TITLE
Fixes a few setup bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,14 @@ First, install the dependencies:
 - numpy
 - matplotlib
 - django
-- django-south
+- south
 - django-extensions
 - pylibmc
 
 Next, follow the usual steps to installing a Django app:
 
 1. Configure `zscore/local_settings.py`. The easiest way is to just copy over `zscore/local_settings.py.dev`.
-2. Run `./manage.py syncdb`
-3. Run `./manage.py migrate`
+2. Run `./manage.py syncdb --migrate`
 
 If you created an admin account in step 2 above, you'll need to create a `SleeperProfile` for it if you want to log in. Run `./manage.py shell`, and then run:
 

--- a/sleep/migrations/0037_load_default_metrics.py
+++ b/sleep/migrations/0037_load_default_metrics.py
@@ -9,8 +9,8 @@ from sleep.models import Metric
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        for s in SleeperProfile.objects.all():
-            for m in Metric.objects.filter(show_by_default=True):
+        for s in orm.SleeperProfile.objects.all():
+            for m in orm.Metric.objects.filter(show_by_default=True):
                 s.metrics.add(m)
 
 


### PR DESCRIPTION
- django-south --> south, to match the PyPI package name
- ./manage.py syncdb --migrate does both the sync and migration
- sleep 0037 just doesn't run unless using the orm version of the model, since the database is in an older state than the model.
